### PR TITLE
fix to use math_ml with Ruby 3.x

### DIFF
--- a/lib/math_ml/latex.rb
+++ b/lib/math_ml/latex.rb
@@ -603,7 +603,7 @@ EOS
 				su = data[0]
 				el = data[1]
 				el = :o unless el
-				s = com.dup.untaint.to_sym unless s
+				s = com.dup.to_sym unless s
 				s = com if s.is_a?(String) && s.length==0
 
 				case el
@@ -622,7 +622,7 @@ EOS
 				end
 
 				case s
-				when Fixnum
+				when Integer
 					s = MathML.pcstring("&\#x#{s.to_s(16)};", true)
 				when ::Symbol
 					s = symbol_table.convert(s)


### PR DESCRIPTION
Hi!
This is a quick fix to use math_ml with Ruby 3.x.
Please check it!
Thank you,
-- Takeshi Nishimatsu
